### PR TITLE
load.js code removal.

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,17 +1,7 @@
 import "../styles/globals.css";
 import Head from "next/head";
-import { useEffect } from "react";
 
 const MyApp = ({ Component, pageProps }) => {
-  // For page hits data, this notifies the server that the page is loaded. Completely optional.
-  useEffect(async () => {
-    await fetch("/api/load", {
-      method: "POST",
-      mode: "cors",
-      credentials: "include",
-    }).catch((err) => console.log(err));
-  }, []);
-
   return (
     <>
       <Head>
@@ -27,9 +17,23 @@ const MyApp = ({ Component, pageProps }) => {
         />
         <meta name="author" content="Omri Geda" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-touch-icon.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png" />
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href="/images/favicon/apple-touch-icon.png"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="/images/favicon/favicon-32x32.png"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="/images/favicon/favicon-16x16.png"
+        />
         <link rel="manifest" href="/images/favicon/site.webmanifest" />
       </Head>
       <Component {...pageProps} />


### PR DESCRIPTION
Even though it works locally in development, the same code that works with a user action (clicking "send" at send.js), doesn't work automatically: Client (useEffect()) => fetch() => api => fetch() to a third party - in production and deployment.
In all cases so far, the data is received with a JSON followed by errors.
A quick search shows it's a known problem.

This can be further investigated at a more convenient time in the future, as this feature isn't a priority and might potentially even be related to something completely different out of the local machine.